### PR TITLE
Fix simulation layout for patient card visibility

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -93,8 +93,8 @@ html, body {
 .app-container {
   display: flex;
   flex-direction: column;
-  height: 100vh;
-  overflow: hidden;
+  min-height: 100vh;
+  overflow-y: auto;
 }
 
 /* Header Styles */
@@ -320,8 +320,8 @@ html, body {
 .simulation-main {
   display: flex;
   flex-direction: column;
-  height: 100%;
-  overflow: hidden;
+  min-height: 100%;
+  overflow: visible;
 }
 
 .simulation-header {
@@ -974,7 +974,7 @@ html, body {
   
   .patient-card {
     max-width: none;
-    order: -1;
+    order: 1;
   }
   
   .intake-form-grid {

--- a/src/index.css
+++ b/src/index.css
@@ -93,8 +93,8 @@ html, body {
 .app-container {
   display: flex;
   flex-direction: column;
-  height: 100vh;
-  overflow: hidden;
+  min-height: 100vh;
+  overflow-y: auto;
 }
 
 /* Header Styles */
@@ -320,8 +320,8 @@ html, body {
 .simulation-main {
   display: flex;
   flex-direction: column;
-  height: 100%;
-  overflow: hidden;
+  min-height: 100%;
+  overflow: visible;
 }
 
 .simulation-header {
@@ -996,7 +996,7 @@ html, body {
   
   .patient-card {
     max-width: none;
-    order: -1;
+    order: 1;
   }
   
   .intake-form-grid {


### PR DESCRIPTION
## Summary
- Allow simulation page to scroll so the full patient card is visible
- Place patient card below simulation content on small screens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894bf5fdda48322af20d73a77d93e3d