### PR TITLE
Display 'No English' for patients without English proficiency

### DIFF
--- a/functions/constants.js
+++ b/functions/constants.js
@@ -1,8 +1,13 @@
 const ENCOUNTER_PHASES = {
   0: {
     name: 'Introduction & Initial Presentation',
-    coachIntro: (patient) =>
-      `Welcome to ECHO! You are entering a patient room, where you will meet ${patient.name}, a ${patient.age}-year-old ${patient.genderIdentity} (${patient.pronouns}) whose primary language is ${patient.nativeLanguage} (${patient.englishProficiency} English proficiency). Their main complaint is: "${patient.mainComplaint}". Your goal is to conduct a complete clinical encounter with cultural humility and shared understanding. Entering Phase 1: Initiation and Building the Relationship. What is your first step?`,
+    coachIntro: (patient) => {
+      const proficiency =
+        patient.englishProficiency === 'None'
+          ? 'No English'
+          : `${patient.englishProficiency} English`;
+      return `Welcome to ECHO! You are entering a patient room, where you will meet ${patient.name}, a ${patient.age}-year-old ${patient.genderIdentity} (${patient.pronouns}) whose primary language is ${patient.nativeLanguage} (${proficiency} proficiency). Their main complaint is: "${patient.mainComplaint}". Your goal is to conduct a complete clinical encounter with cultural humility and shared understanding. Entering Phase 1: Initiation and Building the Relationship. What is your first step?`;
+    },
     phaseGoalDescription: 'This is the initial introduction to the scenario. There are no direct tasks for the provider in this phase other than to transition into Phase 1.',
     maxTurns: 0,
   },

--- a/src/PatientIntakeForm.js
+++ b/src/PatientIntakeForm.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 
 // Import existing patient data files
 import predefinedPatients from './patients/predefinedPatients.json';
+import { formatEnglishProficiency } from './utils/language';
 
 /**
  * ECHO Patient Intake Form Component
@@ -811,7 +812,7 @@ function PatientIntakeForm() {
                 <div className="patient-preview-item">
                   <span className="patient-info-label">Language</span>
                   <span>
-                    {generatedPatient.nativeLanguage} ({generatedPatient.englishProficiency} English)
+                    {generatedPatient.nativeLanguage} ({formatEnglishProficiency(generatedPatient.englishProficiency, true)})
                   </span>
                 </div>
 

--- a/src/SimulationPage.js
+++ b/src/SimulationPage.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef } from "react";
 import predefinedPatients from "./patients/predefinedPatients.json";
 import { ENCOUNTER_PHASES_CLIENT, PHASE_RUBRIC_DEFINITIONS } from "./utils/constants";
+import { formatEnglishProficiency } from "./utils/language";
 import { useSimulation } from "./hooks/useSimulation";
 
 /**
@@ -106,7 +107,7 @@ function SimulationPage() {
                 <p className="patient-info-detail"><span className="patient-info-label">Age:</span> {patientState.age}</p>
                 <p className="patient-info-detail"><span className="patient-info-label">Gender:</span> {patientState.genderIdentity} ({patientState.pronouns})</p>
                 <p className="patient-info-detail"><span className="patient-info-label">Native Language:</span> {patientState.nativeLanguage}</p>
-                <p className="patient-info-detail"><span className="patient-info-label">English Proficiency:</span> {patientState.englishProficiency}</p>
+                <p className="patient-info-detail"><span className="patient-info-label">English Proficiency:</span> {formatEnglishProficiency(patientState.englishProficiency)}</p>
                 <p className="patient-info-detail"><span className="patient-info-label">Cultural Background:</span> {patientState.culturalBackground}</p>
               </div>
               
@@ -494,7 +495,7 @@ function SimulationPage() {
                   </p>
                   <div className="language-proficiency">
                     <span className={`proficiency-badge ${patientState.englishProficiency.toLowerCase().replace(' ', '-')}`}>
-                      {patientState.englishProficiency} English
+                      {formatEnglishProficiency(patientState.englishProficiency, true)}
                     </span>
                   </div>
                 </div>

--- a/src/utils/language.js
+++ b/src/utils/language.js
@@ -1,0 +1,7 @@
+export const formatEnglishProficiency = (proficiency, includeEnglish = false) => {
+  if (!proficiency) return '';
+  if (proficiency === 'None') {
+    return 'No English';
+  }
+  return includeEnglish ? `${proficiency} English` : proficiency;
+};


### PR DESCRIPTION
## Summary
- add formatter to produce "No English" when proficiency is marked None
- use formatter across simulation and intake pages so patient cards and previews avoid "None English"
- update backend introduction to respect "No English" phrasing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894cdc21ac883229ea8f1be9c63ce0a