### PR TITLE
Remove tagline parentheses and align simulation header border

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -328,7 +328,6 @@ html, body {
   background: linear-gradient(135deg, var(--primary-color) 0%, var(--accent-color) 100%);
   color: white;
   padding: 20px 30px;
-  border-radius: 16px 16px 0 0;
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/src/App.js
+++ b/src/App.js
@@ -112,7 +112,7 @@ function App() {
             <div className="title-container">
               <h1 className="title">ECHO</h1>
               <h2 className="subtitle">
-                (Effective Conversations for Healthcare Optimization)
+                Effective Conversations for Healthcare Optimization
               </h2>
             </div>
           </div>

--- a/src/index.css
+++ b/src/index.css
@@ -328,7 +328,6 @@ html, body {
   background: linear-gradient(135deg, var(--primary-color) 0%, var(--accent-color) 100%);
   color: white;
   padding: 20px 30px;
-  border-radius: 16px 16px 0 0;
   display: flex;
   justify-content: space-between;
   align-items: center;


### PR DESCRIPTION
## Summary
- Drop parentheses from the ECHO tagline so the header shows "Effective Conversations for Healthcare Optimization" plainly.
- Adjust simulation progress header to match patient intake styling by removing its rounded corners.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894ce90ee788322bfc93c4690caea8d