### PR TITLE
Fix patient card visibility and responsive layout

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -652,6 +652,7 @@ html, body {
   border: 1px solid #e1e5e9;
   overflow: hidden;
   height: fit-content;
+  flex-shrink: 0;
 }
 
 .patient-card-header {

--- a/public/styles.css
+++ b/public/styles.css
@@ -411,16 +411,17 @@ html, body {
 }
 
 /* Chat Interface */
+
 .simulation-content {
   display: flex;
+  flex-direction: column;
   flex: 1;
   gap: 20px;
   padding: 20px;
-  overflow: hidden;
 }
 
 .chat-section {
-  flex: 2;
+  flex: 1;
   display: flex;
   flex-direction: column;
   min-height: 0;
@@ -644,8 +645,7 @@ html, body {
 
 /* Patient Card */
 .patient-card {
-  flex: 1;
-  max-width: 400px;
+  width: 100%;
   background: white;
   border-radius: 16px;
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
@@ -967,14 +967,17 @@ html, body {
   }
   
   .simulation-content {
-    flex-direction: column;
     gap: var(--spacing-md);
     padding: var(--spacing-md);
   }
-  
+
+  .chat-section {
+    order: 1;
+  }
+
   .patient-card {
     max-width: none;
-    order: 1;
+    order: 2;
   }
   
   .intake-form-grid {

--- a/src/SimulationPage.js
+++ b/src/SimulationPage.js
@@ -283,13 +283,94 @@ function SimulationPage() {
 
         {/* Main Content Area */}
         <div className="simulation-content">
+          {/* Patient Information Card */}
+          {patientState && (
+            <div className="patient-card modern-card">
+              <div className="patient-card-header">
+                <div className="patient-avatar">
+                  <span className="avatar-icon">👤</span>
+                </div>
+                <div className="patient-basic-info">
+                  <h3 className="patient-name">{patientState.name}</h3>
+                  <p className="patient-demographics">
+                    {patientState.age} years old • {patientState.genderIdentity} • {patientState.nativeLanguage} speaker
+                  </p>
+                  <div className="language-proficiency">
+                    <span className={`proficiency-badge ${patientState.englishProficiency.toLowerCase().replace(' ', '-')}`}>
+                      {patientState.englishProficiency} English
+                    </span>
+                  </div>
+                </div>
+              </div>
+
+              <div className="patient-card-content">
+                <div className="complaint-section">
+                  <h4>🩺 Presenting Complaint</h4>
+                  <p className="main-complaint">{patientState.mainComplaint}</p>
+                  {patientState.secondaryComplaint && (
+                    <p className="secondary-complaint">Also: {patientState.secondaryComplaint}</p>
+                  )}
+                </div>
+
+                <div className="cultural-context">
+                  <h4>🌍 Cultural Context</h4>
+                  <p>{patientState.culturalBackground}</p>
+                  <div className="persona-tag">
+                    <span>Persona: {patientState.patientPersona}</span>
+                  </div>
+                </div>
+
+                <div className="patient-perspectives">
+                  <h4>💭 Patient's Perspective</h4>
+                  <div className="perspective-grid">
+                    <div className="perspective-item">
+                      <span className="perspective-label">Ideas:</span>
+                      <p>{patientState.illnessPerception_Ideas}</p>
+                    </div>
+                    <div className="perspective-item">
+                      <span className="perspective-label">Concerns:</span>
+                      <p>{patientState.illnessPerception_Concerns}</p>
+                    </div>
+                    <div className="perspective-item">
+                      <span className="perspective-label">Expectations:</span>
+                      <p>{patientState.illnessPerception_Expectations}</p>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="clinical-summary">
+                  <h4>⚕️ Clinical Summary</h4>
+                  <div className="clinical-grid">
+                    <div className="clinical-item">
+                      <span className="clinical-label">Diagnosis:</span>
+                      <p>{patientState.correctDiagnosis}</p>
+                    </div>
+                    <div className="clinical-item">
+                      <span className="clinical-label">Key History:</span>
+                      <p>{patientState.relevantPastMedicalHistory}</p>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="card-actions">
+                  <button
+                    className="btn-outline"
+                    onClick={() => setShowFullPatientInfo(true)}
+                  >
+                    📋 View Complete Information
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
+
           {/* Chat Interface */}
           <div className="chat-section">
             <div className="chat-window modern-chat" ref={chatWindowRef}>
               {messages.map((msg, index) => (
                 <div key={index} className={`message modern-message ${
-                  msg.from === "patient" ? "patient-message" : 
-                  msg.from === "coach" ? "coach-message" : 
+                  msg.from === "patient" ? "patient-message" :
+                  msg.from === "coach" ? "coach-message" :
                   "provider-message"
                 }`}>
                   <div className="message-header">
@@ -480,86 +561,6 @@ function SimulationPage() {
             )}
           </div>
 
-          {/* Patient Information Card */}
-          {patientState && (
-            <div className="patient-card modern-card">
-              <div className="patient-card-header">
-                <div className="patient-avatar">
-                  <span className="avatar-icon">👤</span>
-                </div>
-                <div className="patient-basic-info">
-                  <h3 className="patient-name">{patientState.name}</h3>
-                  <p className="patient-demographics">
-                    {patientState.age} years old • {patientState.genderIdentity} • {patientState.nativeLanguage} speaker
-                  </p>
-                  <div className="language-proficiency">
-                    <span className={`proficiency-badge ${patientState.englishProficiency.toLowerCase().replace(' ', '-')}`}>
-                      {patientState.englishProficiency} English
-                    </span>
-                  </div>
-                </div>
-              </div>
-
-              <div className="patient-card-content">
-                <div className="complaint-section">
-                  <h4>🩺 Presenting Complaint</h4>
-                  <p className="main-complaint">{patientState.mainComplaint}</p>
-                  {patientState.secondaryComplaint && (
-                    <p className="secondary-complaint">Also: {patientState.secondaryComplaint}</p>
-                  )}
-                </div>
-
-                <div className="cultural-context">
-                  <h4>🌍 Cultural Context</h4>
-                  <p>{patientState.culturalBackground}</p>
-                  <div className="persona-tag">
-                    <span>Persona: {patientState.patientPersona}</span>
-                  </div>
-                </div>
-
-                <div className="patient-perspectives">
-                  <h4>💭 Patient's Perspective</h4>
-                  <div className="perspective-grid">
-                    <div className="perspective-item">
-                      <span className="perspective-label">Ideas:</span>
-                      <p>{patientState.illnessPerception_Ideas}</p>
-                    </div>
-                    <div className="perspective-item">
-                      <span className="perspective-label">Concerns:</span>
-                      <p>{patientState.illnessPerception_Concerns}</p>
-                    </div>
-                    <div className="perspective-item">
-                      <span className="perspective-label">Expectations:</span>
-                      <p>{patientState.illnessPerception_Expectations}</p>
-                    </div>
-                  </div>
-                </div>
-
-                <div className="clinical-summary">
-                  <h4>⚕️ Clinical Summary</h4>
-                  <div className="clinical-grid">
-                    <div className="clinical-item">
-                      <span className="clinical-label">Diagnosis:</span>
-                      <p>{patientState.correctDiagnosis}</p>
-                    </div>
-                    <div className="clinical-item">
-                      <span className="clinical-label">Key History:</span>
-                      <p>{patientState.relevantPastMedicalHistory}</p>
-                    </div>
-                  </div>
-                </div>
-
-                <div className="card-actions">
-                  <button 
-                    className="btn-outline" 
-                    onClick={() => setShowFullPatientInfo(true)}
-                  >
-                    📋 View Complete Information
-                  </button>
-                </div>
-              </div>
-            </div>
-          )}
         </div>
 
         {/* Control Panel */}

--- a/src/SimulationPage.js
+++ b/src/SimulationPage.js
@@ -285,7 +285,7 @@ function SimulationPage() {
         <div className="simulation-content">
           {/* Patient Information Card */}
           {patientState && (
-            <div className="patient-card modern-card">
+            <div className="patient-card">
               <div className="patient-card-header">
                 <div className="patient-avatar">
                   <span className="avatar-icon">👤</span>

--- a/src/index.css
+++ b/src/index.css
@@ -187,7 +187,7 @@ html, body {
 /* Main Content Area */
 .main-content {
   flex: 1;
-  overflow: hidden;
+  overflow-y: auto;
   display: flex;
   flex-direction: column;
 }
@@ -413,14 +413,14 @@ html, body {
 /* Chat Interface */
 .simulation-content {
   display: flex;
+  flex-direction: column;
   flex: 1;
   gap: 20px;
   padding: 20px;
-  overflow: hidden;
 }
 
 .chat-section {
-  flex: 2;
+  flex: 1;
   display: flex;
   flex-direction: column;
   min-height: 0;
@@ -644,8 +644,7 @@ html, body {
 
 /* Patient Card */
 .patient-card {
-  flex: 1;
-  max-width: 400px;
+  width: 100%;
   background: white;
   border-radius: 16px;
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
@@ -989,14 +988,16 @@ html, body {
   }
   
   .simulation-content {
-    flex-direction: column;
     gap: var(--spacing-md);
     padding: var(--spacing-md);
   }
-  
-  .patient-card {
-    max-width: none;
+
+  .chat-section {
     order: 1;
+  }
+
+  .patient-card {
+    order: 2;
   }
   
   .intake-form-grid {

--- a/src/index.css
+++ b/src/index.css
@@ -651,6 +651,7 @@ html, body {
   border: 1px solid #e1e5e9;
   overflow: hidden;
   height: fit-content;
+  flex-shrink: 0;
 }
 
 .patient-card-header {


### PR DESCRIPTION
## Summary
- Show patient info card before chat so it pushes main content down
- Make main content scrollable and stack patient card with chat for better responsiveness
- Reorder sections on small screens to keep chat above patient card

## Testing
- `npm test` *(fails: react-scripts not found)*


------
https://chatgpt.com/codex/tasks/task_e_6894cd65fe6c8322b9a0f74f694e80c8