### PR TITLE
Avoid Phase 1 transition tip

### DIFF
--- a/functions/handlers.js
+++ b/functions/handlers.js
@@ -245,7 +245,7 @@ async function handleInteraction(req, res, geminiApiSecret) {
 
       providerTurnCount = 0;
 
-      if (nextPhaseConfig) {
+      if (nextPhaseConfig && nextPhase > 1) {
         if (nextPhaseConfig.coachIntro) {
           nextCoachMessage = nextPhaseConfig.coachIntro(patientState);
         } else if (nextPhaseConfig.coachPrompt) {


### PR DESCRIPTION
## Summary
- prevent server from sending Phase 1 transition tip since UI already shows this

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894d0cafe5c832281ce0e89226c40b9