### PR TITLE
Improve patient card visibility and responsive layout

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -187,7 +187,7 @@ html, body {
 /* Main Content Area */
 .main-content {
   flex: 1;
-  overflow: hidden;
+  overflow-y: auto;
   display: flex;
   flex-direction: column;
 }
@@ -412,14 +412,15 @@ html, body {
 /* Chat Interface */
 .simulation-content {
   display: flex;
+  flex-direction: column;
   flex: 1;
   gap: 20px;
   padding: 20px;
-  overflow: hidden;
+  overflow: visible;
 }
 
 .chat-section {
-  flex: 2;
+  flex: 1;
   display: flex;
   flex-direction: column;
   min-height: 0;
@@ -643,14 +644,17 @@ html, body {
 
 /* Patient Card */
 .patient-card {
-  flex: 1;
-  max-width: 400px;
+  order: -1;
+  width: 100%;
+  max-width: 600px;
   background: white;
   border-radius: 16px;
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
   border: 1px solid #e1e5e9;
   overflow: hidden;
   height: fit-content;
+  flex: 0 0 auto;
+  margin: 0 auto;
 }
 
 .patient-card-header {
@@ -974,6 +978,7 @@ html, body {
   .patient-card {
     max-width: none;
     order: 1;
+    margin: 0;
   }
   
   .intake-form-grid {

--- a/src/index.css
+++ b/src/index.css
@@ -187,7 +187,7 @@ html, body {
 /* Main Content Area */
 .main-content {
   flex: 1;
-  overflow: hidden;
+  overflow-y: auto;
   display: flex;
   flex-direction: column;
 }
@@ -412,14 +412,15 @@ html, body {
 /* Chat Interface */
 .simulation-content {
   display: flex;
+  flex-direction: column;
   flex: 1;
   gap: 20px;
   padding: 20px;
-  overflow: hidden;
+  overflow: visible;
 }
 
 .chat-section {
-  flex: 2;
+  flex: 1;
   display: flex;
   flex-direction: column;
   min-height: 0;
@@ -643,14 +644,17 @@ html, body {
 
 /* Patient Card */
 .patient-card {
-  flex: 1;
-  max-width: 400px;
+  order: -1;
+  width: 100%;
+  max-width: 600px;
   background: white;
   border-radius: 16px;
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
   border: 1px solid #e1e5e9;
   overflow: hidden;
   height: fit-content;
+  flex: 0 0 auto;
+  margin: 0 auto;
 }
 
 .patient-card-header {
@@ -996,6 +1000,7 @@ html, body {
   .patient-card {
     max-width: none;
     order: 1;
+    margin: 0;
   }
   
   .intake-form-grid {


### PR DESCRIPTION
## Summary
- Stack simulation content vertically and let main area scroll
- Show patient card above the chat on larger screens and move it below on phones
- Adjust chat section sizing to fill remaining space

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894db54a9b4832292746771514376b9