### PR TITLE
Start encounters directly in Phase 1

### DIFF
--- a/functions/constants.js
+++ b/functions/constants.js
@@ -6,7 +6,7 @@ const ENCOUNTER_PHASES = {
         patient.englishProficiency === 'None'
           ? 'No English'
           : `${patient.englishProficiency} English`;
-      return `Welcome to ECHO! You are entering a patient room, where you will meet ${patient.name}, a ${patient.age}-year-old ${patient.genderIdentity} (${patient.pronouns}) whose primary language is ${patient.nativeLanguage} (${proficiency} proficiency). Their main complaint is: "${patient.mainComplaint}". Your goal is to conduct a complete clinical encounter with cultural humility and shared understanding. Entering Phase 1: Initiation and Building the Relationship. What is your first step?`;
+      return `Welcome to ECHO! You are entering a patient room, where you will meet ${patient.name}, a ${patient.age}-year-old ${patient.genderIdentity} (${patient.pronouns}) whose primary language is ${patient.nativeLanguage} (${proficiency} proficiency). Their main complaint is: "${patient.mainComplaint}". Your goal is to conduct a complete clinical encounter with cultural humility and shared understanding. You are in Phase 1 (Initiation & Relationship). Focus on greeting the patient, introducing yourself, establishing rapport, and clearly identifying the patient's chief complaint and agenda for the visit. What is your first step?`;
     },
     phaseGoalDescription: 'This is the initial introduction to the scenario. There are no direct tasks for the provider in this phase other than to transition into Phase 1.',
     maxTurns: 0,

--- a/src/hooks/useSimulation.js
+++ b/src/hooks/useSimulation.js
@@ -82,7 +82,7 @@ export const useSimulation = () => {
         setMessages([{ text: initialCoachMessage, from: 'coach' }]);
         setConversationHistoryForAPI([]);
         setEncounterState({
-          currentPhase: 0,
+          currentPhase: 1,
           providerTurnCount: 0,
           phaseScores: {},
           currentCumulativeScore: 0,
@@ -181,11 +181,6 @@ export const useSimulation = () => {
   };
 
   const handleMoveToNextPhase = async () => {
-    if (encounterState.currentPhase === 0) {
-      setEncounterState(prev => ({ ...prev, currentPhase: 1 }));
-      setMessages((prev) => [...prev, {text: `COACH: You've started Phase 1: ${ENCOUNTER_PHASES_CLIENT[1].name}. ${ENCOUNTER_PHASES_CLIENT[1].coachPrompt || ''}`, from: 'coach'}]);
-      return;
-    }
     await sendInteractionToServer('move_to_next_phase', '');
   };
 
@@ -250,6 +245,13 @@ export const useSimulation = () => {
       setPatientState(patient);
       setMessages([{ text: initialCoachMessage, from: 'coach' }]);
       setSelectedPatientIndex('0');
+      setEncounterState({
+        currentPhase: 1,
+        providerTurnCount: 0,
+        phaseScores: {},
+        currentCumulativeScore: 0,
+        totalPossibleScore: 0,
+      });
     }
   }, [patientState]);
 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -2,7 +2,7 @@ export const ENCOUNTER_PHASES_CLIENT = {
   0: {
     name: "Introduction & Initial Presentation",
     maxScore: 0,
-    coachIntro: (patient) => `Welcome to ECHO! You're about to meet **${patient.name}**, a **${patient.age}**-year-old. Their main complaint is: "${patient.mainComplaint}". Your goal is to conduct a complete clinical encounter adhering to the Patient-Centered / Biopsychosocial model. Let's begin with **Phase 1: Initiation and Building the Relationship**. What is your first step?`
+    coachIntro: (patient) => `Welcome to ECHO! You're about to meet **${patient.name}**, a **${patient.age}**-year-old. Their main complaint is: "${patient.mainComplaint}". Your goal is to conduct a complete clinical encounter adhering to the Patient-Centered / Biopsychosocial model. You are in **Phase 1: Initiation & Building the Relationship**. Focus on greeting the patient, introducing yourself, establishing rapport, and clearly identifying the patient's chief complaint and agenda for the visit. What is your first step?`
   },
   1: { name: "Initiation & Building the Relationship", maxScore: 5 },
   2: { name: "Information Gathering & History Taking", maxScore: 5 },


### PR DESCRIPTION
## Summary
- Include Phase 1 coaching guidance in the introductory message
- Initialize simulations in Phase 1 so the first provider input gets a patient reply
- Simplify manual phase advancement to rely solely on backend handling

## Testing
- `npm test`
- `npm --prefix functions run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894fbf54d3483229d2c44651075791d