### PR TITLE
feat: inline translation for patient responses

### DIFF
--- a/functions/languageUtils.test.js
+++ b/functions/languageUtils.test.js
@@ -1,0 +1,21 @@
+const test = require('node:test');
+const assert = require('assert');
+const { formatPatientResponse } = require('./languageUtils');
+
+test('returns unchanged English text', async () => {
+  const res = await formatPatientResponse('I have a headache.', null, 'en');
+  assert.strictEqual(res, 'I have a headache.');
+});
+
+test('translates entire non-English response', async () => {
+  const res = await formatPatientResponse('Hola mi nombre es Maria.', null, 'es');
+  assert.strictEqual(res, 'Hola mi nombre es Maria (Hello, my name is Maria).');
+});
+
+test('translates only the non-English segment', async () => {
+  const res = await formatPatientResponse('Hello my name is Maria y no puedo caminar bien', null);
+  assert.strictEqual(
+    res,
+    'Hello my name is Maria y no puedo caminar bien (and I cannot walk well)'
+  );
+});


### PR DESCRIPTION
## Summary
- detect non-English segments in patient responses and append English translations inline
- expand translation dictionary for common multilingual phrases
- add unit tests for patient response formatting

## Testing
- `node --test functions/languageUtils.test.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68951e0de0bc832281e8a9b24b6253d8