### PR TITLE
feat: inline translation for patient responses

### DIFF
--- a/functions/languageUtils.js
+++ b/functions/languageUtils.js
@@ -1,17 +1,8 @@
+const translationCache = new Map();
 const translateToEnglish = async (text, srcLang = 'auto') => {
-  const translations = {
-    'Tengo dolor en el estómago.': 'I have pain in my stomach.',
-    'Me duele el estómago y no puedo comer mucho.':
-      "My stomach hurts and I can't eat much.",
-    'Estoy mareado y me duele la cabeza.': "I'm dizzy and my head hurts.",
-    'Hola mi nombre es Maria.': 'Hello, my name is Maria.',
-    'y no puedo caminar bien': 'and I cannot walk well.',
-    'Hello my name is Maria y no puedo caminar bien':
-      'Hello my name is Maria and I cannot walk well.',
-  };
-
-  if (translations[text]) {
-    return translations[text];
+  const cacheKey = `${srcLang}:${text}`;
+  if (translationCache.has(cacheKey)) {
+    return translationCache.get(cacheKey);
   }
 
   const langCodes = {
@@ -29,16 +20,23 @@ const translateToEnglish = async (text, srcLang = 'auto') => {
   const fromLang = langCodes[srcLang?.toLowerCase?.()] || srcLang;
 
   try {
-    const url = `https://translate.googleapis.com/translate_a/single?client=gtx&sl=${fromLang}&tl=en&dt=t&q=${encodeURIComponent(text)}`;
+    const url = `https://translate.googleapis.com/translate_a/single?client=gtx&sl=${fromLang}&tl=en&dt=t&q=${encodeURIComponent(
+      text,
+    )}`;
     const res = await fetch(url);
     const data = await res.json();
     if (Array.isArray(data) && data[0] && data[0][0] && data[0][0][0]) {
-      return data[0][0][0];
+      const result = { text: data[0][0][0], src: data[2] };
+      translationCache.set(cacheKey, result);
+      return result;
     }
   } catch (err) {
     console.error('translateToEnglish: translation failed', err);
   }
-  return `[translation unavailable for: ${text}]`;
+  return {
+    text: `[translation unavailable for: ${text}]`,
+    src: srcLang,
+  };
 };
 
 // Detect and translate only the non-English segments of a patient response.
@@ -46,41 +44,90 @@ const translateToEnglish = async (text, srcLang = 'auto') => {
 const formatPatientResponse = async (rawText, _proficiency, srcLang = 'auto') => {
   if (!rawText) return '';
 
-  // Split by spaces but keep them in the array for reconstruction
-  const segments = rawText.split(/(\s+)/);
+  const tokens =
+    rawText.match(/([\p{L}\p{M}]+|[^\p{L}\p{M}\s]+|\s+)/gu) || [rawText];
   const processed = [];
+  let segmentTokens = [];
+  let segmentIsNonEnglish = null;
 
-  for (const segment of segments) {
-    // If it's purely whitespace, keep as is
-    if (!segment.trim()) {
-      processed.push(segment);
-      continue;
-    }
+  const flush = async () => {
+    if (!segmentTokens.length) return;
+    const phrase = segmentTokens.join('');
+    const match = phrase.match(/^(.*?)(\s*)$/s);
+    const core = match[1];
+    const trailing = match[2];
 
-    // Separate word from attached punctuation (e.g., "Hola,")
-    const match = segment.match(/^(\p{L}+[\p{M}]*)(.*)$/u);
-    if (!match) {
-      processed.push(segment);
-      continue;
-    }
-
-    const word = match[1];
-    const punctuation = match[2] || '';
-
-    const translation = await translateToEnglish(word, srcLang);
-    const translationAvailable =
-      translation && !translation.startsWith('[translation unavailable');
-
-    if (
-      translationAvailable &&
-      translation.trim().toLowerCase() !== word.trim().toLowerCase()
-    ) {
-      processed.push(`${word} (${translation})${punctuation}`);
+    if (segmentIsNonEnglish) {
+      const { text: translated } = await translateToEnglish(core.trim(), srcLang);
+      const translationAvailable =
+        translated && !translated.startsWith('[translation unavailable');
+      if (
+        translationAvailable &&
+        translated.trim().toLowerCase() !== core.trim().toLowerCase()
+      ) {
+        processed.push(`${core} (${translated})${trailing}`);
+      } else {
+        processed.push(phrase);
+      }
     } else {
-      processed.push(word + punctuation);
+      processed.push(phrase);
     }
+
+    segmentTokens = [];
+    segmentIsNonEnglish = null;
+  };
+
+  for (const token of tokens) {
+    if (/^\s+$/.test(token)) {
+      if (segmentTokens.length) {
+        segmentTokens.push(token);
+      } else {
+        processed.push(token);
+      }
+      continue;
+    }
+
+    if (/^[\p{L}\p{M}]+$/u.test(token)) {
+      const { text: translated, src: detectedSrc } = await translateToEnglish(
+        token,
+        srcLang,
+      );
+      const translationAvailable =
+        translated && !translated.startsWith('[translation unavailable');
+      let isNonEnglish = false;
+      if (translationAvailable) {
+        const same =
+          translated.trim().toLowerCase() === token.trim().toLowerCase();
+        if (detectedSrc && detectedSrc !== 'en') {
+          // If translation differs, starts lowercase, or we are already in a
+          // non-English segment, treat as non-English. This keeps proper nouns
+          // within foreign-language segments but preserves standalone names in
+          // English segments.
+          if (!same || /^[a-z]/.test(token) || segmentIsNonEnglish) {
+            isNonEnglish = true;
+          }
+        } else {
+          isNonEnglish = !same;
+        }
+      } else {
+        isNonEnglish = segmentTokens.length ? segmentIsNonEnglish : false;
+      }
+
+      if (segmentTokens.length && segmentIsNonEnglish !== isNonEnglish) {
+        await flush();
+      }
+      if (!segmentTokens.length) {
+        segmentIsNonEnglish = isNonEnglish;
+      }
+      segmentTokens.push(token);
+      continue;
+    }
+
+    await flush();
+    processed.push(token);
   }
 
+  await flush();
   return processed.join('');
 };
 

--- a/functions/languageUtils.test.js
+++ b/functions/languageUtils.test.js
@@ -1,0 +1,61 @@
+const { test, before, after } = require('node:test');
+const assert = require('assert');
+const { formatPatientResponse } = require('./languageUtils');
+
+const originalFetch = global.fetch;
+const mockTranslations = {
+  Hola: { translation: 'Hello', src: 'es' },
+  mi: { translation: 'my', src: 'es' },
+  nombre: { translation: 'name', src: 'es' },
+  es: { translation: 'is', src: 'es' },
+  Maria: { translation: 'Maria', src: 'es' },
+  y: { translation: 'and', src: 'es' },
+  no: { translation: 'no', src: 'es' },
+  puedo: { translation: 'can', src: 'es' },
+  caminar: { translation: 'walk', src: 'es' },
+  bien: { translation: 'well', src: 'es' },
+  'Hola mi nombre es Maria': {
+    translation: 'Hello, my name is Maria',
+    src: 'es',
+  },
+  'y no puedo caminar bien': {
+    translation: 'and I cannot walk well',
+    src: 'es',
+  },
+  'Hello my name is Maria y no puedo caminar bien': {
+    translation: 'Hello my name is Maria and I cannot walk well',
+    src: 'es',
+  },
+};
+
+before(() => {
+  global.fetch = async (url) => {
+    const q = new URL(url).searchParams.get('q');
+    const entry = mockTranslations[q] || { translation: q, src: 'en' };
+    return {
+      json: async () => [[[entry.translation, q]], null, entry.src],
+    };
+  };
+});
+
+after(() => {
+  global.fetch = originalFetch;
+});
+
+test('returns unchanged English text', async () => {
+  const res = await formatPatientResponse('I have a headache.', null, 'en');
+  assert.strictEqual(res, 'I have a headache.');
+});
+
+test('translates entire non-English response', async () => {
+  const res = await formatPatientResponse('Hola mi nombre es Maria.', null, 'es');
+  assert.strictEqual(res, 'Hola mi nombre es Maria (Hello, my name is Maria).');
+});
+
+test('translates only the non-English segment', async () => {
+  const res = await formatPatientResponse('Hello my name is Maria y no puedo caminar bien', null);
+  assert.strictEqual(
+    res,
+    'Hello my name is Maria y no puedo caminar bien (and I cannot walk well)'
+  );
+});


### PR DESCRIPTION
## Summary
- call external translation service for non-English content and cache results
- refine patient response formatting to preserve names while translating surrounding text
- mock translation API in tests to validate inline translations

## Testing
- `node --test functions/languageUtils.test.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68951e0de0bc832281e8a9b24b6253d8