### PR TITLE
Ensure patient replies always include English translation

### DIFF
--- a/functions/languageUtils.js
+++ b/functions/languageUtils.js
@@ -1,5 +1,42 @@
-const formatPatientResponse = async (rawText) => {
-  return rawText || '';
+/**
+ * Ensures patient responses are always understandable by the provider.
+ * If the response is not in English, an inline English translation is appended
+ * in the form: "<original> (English: <translation>)". If translation fails, the
+ * original text is returned.
+ *
+ * @param {string} rawText The text returned by the simulator.
+ * @param {string} [englishProficiency] Patient's English proficiency level.
+ * @param {string} [nativeLanguage] Patient's native language.
+ * @returns {Promise<string>} Formatted response with inline translation when needed.
+ */
+const formatPatientResponse = async (rawText, englishProficiency = '', nativeLanguage = '') => {
+  if (!rawText) return '';
+
+  // Only attempt translation if patient is not fluent
+  const needsTranslation = englishProficiency && englishProficiency.toLowerCase() !== 'fluent';
+  if (!needsTranslation) return rawText;
+
+  try {
+    const url = `https://translate.googleapis.com/translate_a/single?client=gtx&sl=auto&tl=en&dt=t&q=${encodeURIComponent(rawText)}`;
+    const response = await fetch(url);
+    const data = await response.json();
+    const translation = data?.[0]?.[0]?.[0];
+    const detectedLang = data?.[2];
+
+    if (!translation || typeof translation !== 'string') {
+      return `${rawText} (English: translation unavailable)`;
+    }
+
+    // If Google thinks the text is already English, return it unchanged
+    if (detectedLang === 'en' || translation.toLowerCase() === rawText.toLowerCase()) {
+      return rawText;
+    }
+
+    return `${rawText} (English: ${translation})`;
+  } catch (err) {
+    console.error('formatPatientResponse translation error:', err);
+    return `${rawText} (English: translation unavailable)`;
+  }
 };
 
 module.exports = { formatPatientResponse };

--- a/functions/languageUtils.test.js
+++ b/functions/languageUtils.test.js
@@ -7,7 +7,8 @@ test('returns English text unchanged', async () => {
   assert.strictEqual(res, 'I have a headache.');
 });
 
-test('returns non-English text unchanged', async () => {
-  const res = await formatPatientResponse('Hola mi nombre es Maria.');
-  assert.strictEqual(res, 'Hola mi nombre es Maria.');
+test('adds inline translation for non-English text', async () => {
+  const res = await formatPatientResponse('Hola mi nombre es Maria.', 'None', 'Spanish');
+  assert.ok(res.startsWith('Hola mi nombre es Maria.'));
+  assert.ok(res.includes('English:'));
 });


### PR DESCRIPTION
## Summary
- add translation helper to format patient responses with inline English versions or fallback when unavailable
- cover translation behavior with new tests

## Testing
- `npm test`
- `node --test functions/languageUtils.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68996579699c83229f911ab8f4b6e0f3