### PR TITLE
Auto-translate patient messages based on detected language

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ ECHO is an AI-powered clinical simulation platform that helps healthcare provide
 - **Patient scenario generator** – create custom patient profiles manually or from natural-language descriptions that are expanded with Gemini.
 - **Help & advice** – ask the AI for cultural or clinical guidance during a simulation.
 - **Local patient library** – save generated patients in the browser for later use.
+- **Automatic translation** – patient responses are translated to English when needed so providers can always understand them.
 
 ## Getting Started
 

--- a/functions/handlers.js
+++ b/functions/handlers.js
@@ -129,11 +129,8 @@ async function handleInteraction(req, res, geminiApiSecret) {
         phaseComplete = geminiRegularResponse.phaseAssessment.phaseComplete;
         justificationForCompletion = geminiRegularResponse.phaseAssessment.justificationForCompletion;
         if (from === 'patient') {
-          simulatorResponse = await formatPatientResponse(
-            simulatorResponse,
-            patientState.englishProficiency,
-            patientState.nativeLanguage,
-          );
+          // Auto-translate patient responses when not in English
+          simulatorResponse = await formatPatientResponse(simulatorResponse);
         }
         updatedConversationHistory.push({ role: from, parts: [{ text: simulatorResponse }] });
         for (const category in scoreUpdate) {
@@ -200,11 +197,8 @@ async function handleInteraction(req, res, geminiApiSecret) {
         phaseComplete = patientReactionData.phaseAssessment.phaseComplete;
         justificationForCompletion = patientReactionData.phaseAssessment.justificationForCompletion;
         if (from === 'patient') {
-          simulatorResponse = await formatPatientResponse(
-            simulatorResponse,
-            patientState.englishProficiency,
-            patientState.nativeLanguage,
-          );
+          // Auto-translate patient responses when not in English
+          simulatorResponse = await formatPatientResponse(simulatorResponse);
         }
         updatedConversationHistory.push({ role: from, parts: [{ text: simulatorResponse }] });
         for (const category in scoreUpdate) {

--- a/functions/languageUtils.test.js
+++ b/functions/languageUtils.test.js
@@ -3,12 +3,46 @@ const assert = require('assert');
 const { formatPatientResponse } = require('./languageUtils');
 
 test('returns English text unchanged', async () => {
-  const res = await formatPatientResponse('I have a headache.');
-  assert.strictEqual(res, 'I have a headache.');
+  const originalFetch = global.fetch;
+  global.fetch = async () => ({ json: async () => [[['I have a headache.']], null, 'en'] });
+  try {
+    const res = await formatPatientResponse('I have a headache.');
+    assert.strictEqual(res, 'I have a headache.');
+  } finally {
+    global.fetch = originalFetch;
+  }
 });
 
-test('adds inline translation for non-English text', async () => {
-  const res = await formatPatientResponse('Hola mi nombre es Maria.', 'None', 'Spanish');
-  assert.ok(res.startsWith('Hola mi nombre es Maria.'));
-  assert.ok(res.includes('English:'));
+test('adds inline translation for Spanish text', async () => {
+  const originalFetch = global.fetch;
+  global.fetch = async () => ({ json: async () => [[['Hello my name is Maria.']], null, 'es'] });
+  try {
+    const res = await formatPatientResponse('Hola mi nombre es Maria.', 'Fluent');
+    assert.strictEqual(res, 'Hola mi nombre es Maria. (English: Hello my name is Maria.)');
+  } finally {
+    global.fetch = originalFetch;
+  }
 });
+
+test('adds inline translation for French text', async () => {
+  const originalFetch = global.fetch;
+  global.fetch = async () => ({ json: async () => [[["My name is John."]], null, 'fr'] });
+  try {
+    const res = await formatPatientResponse("Bonjour, je m'appelle Jean.");
+    assert.strictEqual(res, "Bonjour, je m'appelle Jean. (English: My name is John.)");
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test('handles translation failure gracefully', async () => {
+  const originalFetch = global.fetch;
+  global.fetch = async () => { throw new Error('Network error'); };
+  try {
+    const res = await formatPatientResponse('こんにちは');
+    assert.strictEqual(res, 'こんにちは (English: translation unavailable)');
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+


### PR DESCRIPTION
## Summary
- Detect language of patient responses and translate non-English messages automatically
- Ensure all patient message branches invoke the translator
- Expand language utilities tests for multiple languages and error handling
- Document automatic translation feature

## Testing
- `node --test languageUtils.test.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68996e6b35808322a9723c020f177f66