### PR TITLE
Make chat window height dynamic

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -419,8 +419,8 @@ html, body {
   overflow: visible;
 }
 
+
 .chat-section {
-  flex: 1;
   display: flex;
   flex-direction: column;
   min-height: 0;
@@ -433,7 +433,6 @@ html, body {
   padding: 20px;
   overflow-y: auto;
   max-height: 1050px;
-  flex: 1;
   margin-bottom: 20px;
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -425,7 +425,7 @@ html, body {
   display: flex;
   flex-direction: column;
   min-height: 0;
-  height: 100%;
+  align-self: flex-start;
 }
 
 .modern-chat {
@@ -435,7 +435,6 @@ html, body {
   padding: 20px;
   overflow-y: auto;
   max-height: 1050px;
-  flex: 1;
   margin-bottom: 20px;
 }
 


### PR DESCRIPTION
## Summary
- Let chat section and window size themselves based on content instead of stretching to full height.
- Cap chat window height at current maximum while enabling scrolling beyond that limit.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899fdb8fda88322b4a484e66d2e1078