### PR TITLE
Render bold phrases in chat messages

### DIFF
--- a/src/SimulationPage.js
+++ b/src/SimulationPage.js
@@ -55,6 +55,13 @@ function SimulationPage() {
     downloadTranscript,
   } = useSimulation();
 
+  const formatText = (text) => {
+    if (!text) return "";
+    return text
+      .replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
+      .replace(/\n/g, '<br>');
+  };
+
   /**
    * Reference to chat window for auto-scrolling to latest message
    */
@@ -304,7 +311,7 @@ function SimulationPage() {
                     </span>
                   </div>
                   <div className="message-content">
-                    <p dangerouslySetInnerHTML={{__html: msg.text}}></p>
+                    <p dangerouslySetInnerHTML={{ __html: formatText(msg.text) }}></p>
                   </div>
                 </div>
               ))}
@@ -457,7 +464,7 @@ function SimulationPage() {
                     <div className="feedback-section">
                       <h3>📝 Overall Feedback</h3>
                       <div className="feedback-content">
-                        <p dangerouslySetInnerHTML={{__html: overallFeedback}}></p>
+                        <p dangerouslySetInnerHTML={{ __html: formatText(overallFeedback) }}></p>
                       </div>
                     </div>
                   )}


### PR DESCRIPTION
## Summary
- Interpret markdown-style `**` in messages and feedback, converting to HTML `<strong>` tags
- Display formatted text in chat window and overall feedback sections

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a00485a0c83228733f71763836368